### PR TITLE
Remove IsPublic property and update related logic/UI

### DIFF
--- a/GymLogger.Api/GymLogger.Api.Client/Pages/Exercises/Components/ExerciseFormDialog.razor
+++ b/GymLogger.Api/GymLogger.Api.Client/Pages/Exercises/Components/ExerciseFormDialog.razor
@@ -36,9 +36,6 @@
                 }
             </FluentSelect>
             <FluentValidationMessage For="@(() => Content.ExerciseLogType)" />
-
-            <FluentSwitch @bind-Value=Content.IsPublic Label="Public exercise" />
-
             <FluentTextArea @bind-Value="@Content.Description" style="width:100%">Description:</FluentTextArea>
         </FluentStack>
     </FluentDialogBody>

--- a/GymLogger.Api/GymLogger.Api.Client/Pages/Exercises/Index.razor
+++ b/GymLogger.Api/GymLogger.Api.Client/Pages/Exercises/Index.razor
@@ -34,9 +34,7 @@
         PagedResponse="_pagedResponseDto"
         PagedRequest="PagedRequestDto"
         PagedRequestChanged="LoadDataAsync"
-        OnDetailsClicked="Details"
-        OnEditClicked="EditAsync"
-        OnDeleteClicked="DeleteAsync">
+        ShowActionButtons="false">
         <ItemTemplate>                
             <FluentLabel Typo="Typography.PaneHeader">@context.Name</FluentLabel>
             <FluentLabel Typo="Typography.Body"><b>Muslce group:</b> @context.MuscleGroupName</FluentLabel>
@@ -45,6 +43,18 @@
             }
             <FluentLabel Typo="Typography.Body"><b>Log type:</b> @desc</FluentLabel>
             <FluentLabel Typo="Typography.Body"><b>Description:</b> @context.Description</FluentLabel>                           
+
+            @if (!context.IsPublic)
+            {
+                <FluentStack HorizontalAlignment="HorizontalAlignment.End">
+                        <FluentButton OnClick="@(() => Details(context))"
+                                      IconEnd="@(new Icons.Regular.Size16.Search())" />
+                        <FluentButton OnClick="@(() => EditAsync(context))"
+                                      IconEnd="@(new Icons.Regular.Size16.Edit())" />
+                        <FluentButton OnClick="@(() => DeleteAsync(context))"
+                                      IconEnd="@(new Icons.Regular.Size16.Delete())" />
+                </FluentStack>
+            }
         </ItemTemplate>
     </GlCardGrid>
 </FluentStack>

--- a/GymLogger.Api/GymLogger.Api.Client/Pages/Exercises/Index.razor.cs
+++ b/GymLogger.Api/GymLogger.Api.Client/Pages/Exercises/Index.razor.cs
@@ -79,7 +79,6 @@ public partial class Index : BaseComponent
             Name = dto.Name,
             MuscleGroupId = dto.MuscleGroupId,
             ExerciseLogType = dto.ExerciseLogType,
-            IsPublic = dto.IsPublic
         };
 
         var dialog = await DialogService.ShowDialogAsync<ExerciseFormDialog>(createDto, new DialogParameters()
@@ -99,7 +98,6 @@ public partial class Index : BaseComponent
                 Name = ((ExerciseCreateDto)result.Data).Name,
                 MuscleGroupId = ((ExerciseCreateDto)result.Data).MuscleGroupId,
                 ExerciseLogType = ((ExerciseCreateDto)result.Data).ExerciseLogType,
-                IsPublic = ((ExerciseCreateDto)result.Data).IsPublic
             };
             try
             {

--- a/GymLogger.Core/Exercise/ExerciseCreate.cs
+++ b/GymLogger.Core/Exercise/ExerciseCreate.cs
@@ -8,5 +8,4 @@ public class ExerciseCreate : IExerciseCreate
     public Guid MuscleGroupId { get; set; }
     public string? Description { get; set; }
     public ExerciseLogType ExerciseLogType { get; set; }
-    public bool IsPublic { get; set; }
 }

--- a/GymLogger.Core/Exercise/Interfaces/IExerciseCreate.cs
+++ b/GymLogger.Core/Exercise/Interfaces/IExerciseCreate.cs
@@ -8,5 +8,4 @@ public interface IExerciseCreate
     Guid MuscleGroupId { get; set; }
     string? Description { get; set; }
     ExerciseLogType ExerciseLogType { get; set; }
-    bool IsPublic { get; set; }
 }

--- a/GymLogger.Infrastructure.Database/Models/Exercise/ExerciseRepository.cs
+++ b/GymLogger.Infrastructure.Database/Models/Exercise/ExerciseRepository.cs
@@ -91,7 +91,7 @@ internal class ExerciseRepository(GymLoggerDbContext dbContext, ICurrentUserProv
             ExerciseLogType = exercise.ExerciseLogType,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,
-            BelongsToUserId = exercise.IsPublic ? null : currentUserProvider.GetCurrentUserId()
+            BelongsToUserId = currentUserProvider.GetCurrentUserId()
         };
 
         try
@@ -125,7 +125,6 @@ internal class ExerciseRepository(GymLoggerDbContext dbContext, ICurrentUserProv
             dbEntity.Description = exercise.Description;
             dbEntity.MuscleGroupId = exercise.MuscleGroupId;
             dbEntity.ExerciseLogType = exercise.ExerciseLogType;
-            dbEntity.BelongsToUserId = exercise.IsPublic ? null : currentUserProvider.GetCurrentUserId();
             dbEntity.UpdatedAt = DateTime.Now;
 
             await dbContext.SaveChangesAsync();

--- a/GymLogger.Shared/Models/Exercise/ExerciseCreateDto.cs
+++ b/GymLogger.Shared/Models/Exercise/ExerciseCreateDto.cs
@@ -15,6 +15,4 @@ public class ExerciseCreateDto
 
     [EnumValidation(typeof(ExerciseLogType), allowZero: false, ErrorMessage = "Select on of options")]
     public ExerciseLogType ExerciseLogType { get; set; }
-
-    public bool IsPublic { get; set; }
 }


### PR DESCRIPTION
The `IsPublic` property has been removed from various parts of the codebase, including Razor components, data transfer objects, and repository logic. Specifically:

- `ExerciseFormDialog.razor`: Removed `FluentSwitch` for `Content.IsPublic` and `FluentTextArea` for `Content.Description`.
- `Index.razor`: Replaced event handlers with `ShowActionButtons="false"` and added conditional display of action buttons based on exercise's public status.
- `Index.razor.cs`: Removed `IsPublic` property from `ExerciseCreateDto` and `ExerciseEditDto`.
- `ExerciseCreate.cs`: Removed `IsPublic` property from `ExerciseCreate` class.
- `IExerciseCreate.cs`: Removed `IsPublic` property from `IExerciseCreate` interface.
- `ExerciseRepository.cs`: Simplified logic to always set `BelongsToUserId` to the current user's ID.
- `ExerciseCreateDto.cs`: Removed `IsPublic` property from `ExerciseCreateDto`.

These changes simplify the codebase by removing the `IsPublic` property and updating the UI and logic accordingly.

Closes #105 